### PR TITLE
ci: move rust-cache before binstall

### DIFF
--- a/.github/actions/basics/action.yml
+++ b/.github/actions/basics/action.yml
@@ -24,6 +24,14 @@ runs:
 
     # ===============================================
 
+    - uses: Swatinem/rust-cache@v2
+
+    - uses: ./.github/actions/elapsed-time
+      with:
+        statement: "rust-cache"
+
+    # ===============================================
+
     - uses: cargo-bins/cargo-binstall@main
 
     # ===============================================
@@ -48,14 +56,6 @@ runs:
     - uses: ./.github/actions/elapsed-time
       with:
         statement: "install cargo-deny,cargo-spellcheck"
-
-    # ===============================================
-
-    - uses: Swatinem/rust-cache@v2
-
-    - uses: ./.github/actions/elapsed-time
-      with:
-        statement: "rust-cache"
 
     # ===============================================
 


### PR DESCRIPTION
avoid binaries installed by cargo-binstall from
being removed by rust-cache