### PR TITLE
ci: add link checker workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,30 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 0 of every hour
+    - cron: "0 * * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,3 @@
 # The Grafana instance is not stable and may occasionally keep reloading without response.
-https://planetsacademe0j.grafana.net/d/fe5wp1pxzgzr4a/leetcode-rs
+# Keep waking up the instance via workflows/links.yml
+# https://planetsacademe0j.grafana.net/d/fe5wp1pxzgzr4a/leetcode-rs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         name: link validation
         language: system
         entry: lychee
-        args: ["--no-progress", "--cache"]
+        args: ["--no-progress"] # , "--cache"
 
       - id: sorted-dictionary-check
         name: make sure dictionary words are sorted and unique


### PR DESCRIPTION
Instead of ignoring Grafana instance in .lycheeignore, keep waking up the instance via workflows/links.yml. Stop using --cache for lychee as it caches the error results even when the instance is running normally.