### PR TITLE
ci: check link one time a day

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    # Runs at minute 0 of every hour
-    - cron: "0/15 * * * *"
+    # Runs at 00:00 UTC every day
+    - cron: "0 0 * * *"
 
 jobs:
   linkChecker:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,6 @@
-# The Grafana instance is not stable and may occasionally keep reloading without response.
-# Keep waking up the instance via workflows/links.yml
-# https://planetsacademe0j.grafana.net/d/fe5wp1pxzgzr4a/leetcode-rs
+# Ignore this Grafana instance since it may occasionally keep reloading
+# without response.
+# Alternatively, keep waking up the instance via:
+# - UptimeRobot
+# - EasyCron
+https://planetsacademe0j.grafana.net/d/fe5wp1pxzgzr4a/leetcode-rs


### PR DESCRIPTION
wake up the Grafana instance via third-party
services instead.